### PR TITLE
Split out macos xcode as a layer

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,24 +14,33 @@ steps:
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 
+  - wait
+  - name: ":package: :ubuntu: :buildkite: 16.04"
+    command: .buildkite/build.sh ubuntu-buildkite-16.04 ubuntu-16.04
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+
+  - name: ":package: vmkite"
+    command: .buildkite/build.sh vmkite ubuntu-16.04
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+
+  - wait
   - name: ":package: :mac: 10.12"
     command: .buildkite/build.sh macos-10.12
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 
   - wait
-  - name: ":package: vmkite"
-    command: .buildkite/build.sh vmkite ubuntu-16.04
+  - name: ":package: :mac: xcode 10.12"
+    command: .buildkite/build.sh macos-xcode-10.12 macos-10.12
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 
+  - wait
   - name: ":package: :mac: :buildkite: 10.12"
-    command: .buildkite/build.sh macos-buildkite-10.12 macos-10.12
+    command: .buildkite/build.sh macos-buildkite-10.12 macos-xcode-10.12
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 
-  - name: ":package: :ubuntu: :buildkite: 16.04"
-    command: .buildkite/build.sh ubuntu-buildkite-16.04 ubuntu-16.04
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,17 @@ validate:
 	packer version
 	packer validate -syntax-only macos-10.12.json
 	packer validate -syntax-only ubuntu-16.04.json
+	packer validate -syntax-only macos-xcode-10.12.json
 	packer validate -syntax-only macos-buildkite-10.12.json
 	packer validate -syntax-only ubuntu-buildkite-16.04.json
 	packer validate -syntax-only vmkite.json
 
-# Base images - Minimal installs
-# ------------------------------
+clean:
+	-rm -rf output/
+	-rm -rf installers/
+
+# macOS images
+# -------------------------------------------------------------
 
 macos-10.12:
 	packer build $(packer_args) \
@@ -21,14 +26,12 @@ macos-10.12:
 		-var output_directory="$(output_directory)" \
 		macos-10.12.json
 
-ubuntu-16.04:
+macos-xcode-10.12:
 	packer build $(packer_args) \
-		-var headless=$(headless) \
+		-var headless=false \
+		-var source_path="$(source_path)" \
 		-var output_directory="$(output_directory)" \
-		ubuntu-16.04.json
-
-# Buildkite images - Base images with buildkite and build tools
-# -------------------------------------------------------------
+		macos-xcode-10.12.json
 
 macos-buildkite-10.12:
 	packer build $(packer_args) \
@@ -37,15 +40,14 @@ macos-buildkite-10.12:
 		-var output_directory="$(output_directory)" \
 		macos-buildkite-10.12.json
 
-ubuntu-buildkite-16.04:
+# ubuntu images
+# -------------------------------------------------------------
+
+ubuntu-16.04:
 	packer build $(packer_args) \
 		-var headless=$(headless) \
-		-var source_path="$(source_path)" \
 		-var output_directory="$(output_directory)" \
-		ubuntu-buildkite-16.04.json
-
-# Other images
-# -------------------------------------------------------------
+		ubuntu-16.04.json
 
 vmkite:
 	packer build $(packer_args) \
@@ -54,6 +56,9 @@ vmkite:
 		-var output_directory="$(output_directory)" \
 		vmkite.json
 
-clean:
-	-rm -rf output/
-	-rm -rf installers/
+ubuntu-buildkite-16.04:
+	packer build $(packer_args) \
+		-var headless=$(headless) \
+		-var source_path="$(source_path)" \
+		-var output_directory="$(output_directory)" \
+		ubuntu-buildkite-16.04.json

--- a/macos-xcode-10.12.json
+++ b/macos-xcode-10.12.json
@@ -41,11 +41,14 @@
       "environment_vars": [
         "HOME_DIR=/Users/vmkite",
         "USERNAME=vmkite",
-        "PASSWORD=vmkite"
+        "PASSWORD=vmkite",
+        "FASTLANE_USER={{user `fastlane_user`}}",
+        "FASTLANE_PASSWORD={{user `fastlane_password`}}",
+        "XCODE_VERSION={{user `xcode_version`}}"
       ],
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
       "scripts": [
-        "scripts/macos/buildkite.sh",
+        "scripts/macos/xcode.sh",
         "scripts/macos/shrink.sh"
       ],
       "type": "shell"
@@ -57,8 +60,11 @@
     "memory": "8096",
     "headless": "",
     "source_path": "",
-    "vm_name": "macos-buildkite-10.12.3-r{{env `BUILDKITE_BUILD_NUMBER`}}",
+    "vm_name": "macos-xcode-10.12.3-r{{env `BUILDKITE_BUILD_NUMBER`}}",
     "output_directory": "output",
-    "vnc_bind_address": "0.0.0.0"
+    "vnc_bind_address": "0.0.0.0",
+    "fastlane_user": "{{env `FASTLANE_USER`}}",
+    "fastlane_password": "{{env `FASTLANE_PASSWORD`}}",
+    "xcode_version": "8.3.2"
   }
 }

--- a/scripts/macos/xcode.sh
+++ b/scripts/macos/xcode.sh
@@ -7,3 +7,4 @@ if [ -z "${XCODE_VERSION:-}" ] ; then
 fi
 
 /usr/local/bin/xcversion install "$XCODE_VERSION"
+/usr/local/bin/xcversion cleanup


### PR DESCRIPTION
This allows for faster iteration on the Buildkite images by adding XCode in a different layer. This makes the overall hierarchy: 

* Base macOS
* XCode
* Buildkite + Tools